### PR TITLE
Fix updateBinding return propagation for row binding updates

### DIFF
--- a/services/selection-binding-service.js
+++ b/services/selection-binding-service.js
@@ -1009,6 +1009,8 @@ export class SelectionBindingService {
                 return { success: false, error: e.message };
             }
         });
+
+        return updateResult;
     }
 
     // 为当前光标所在行绑定隐藏数据


### PR DESCRIPTION
### Motivation
- A refactor in `updateBinding` assigned the `runInDoc` result to a local variable but did not return it, causing callers to receive `undefined` and making `UPDATE_BINDING` always appear to fail.

### Description
- Add a `return updateResult;` at the end of `SelectionBindingService.updateBinding` in `services/selection-binding-service.js` so the `runInDoc` response is propagated to callers.

### Testing
- Ran `node --check services/selection-binding-service.js` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f2396ad88331a664292f31ae4ff8)